### PR TITLE
Complex improvements for DNS over TLS forwarder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mikispag/dns-over-tls-forwarder
 go 1.20
 
 require (
-	github.com/miekg/dns v1.1.53
+	github.com/miekg/dns v1.1.55
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/sync v0.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mikispag/dns-over-tls-forwarder
 go 1.20
 
 require (
+	github.com/gologme/log v1.3.0
 	github.com/miekg/dns v1.1.55
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gologme/log v1.3.0 h1:l781G4dE+pbigClDSDzSaaYKtiueHCILUa/qSDsmHAo=
+github.com/gologme/log v1.3.0/go.mod h1:yKT+DvIPdDdDoPtqFrFxheooyVmoqi0BAsw+erN3wA4=
 github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=
 github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/miekg/dns v1.1.53 h1:ZBkuHr5dxHtB1caEOlZTLPo7D3L3TWckgUUs/RHfDxw=
-github.com/miekg/dns v1.1.53/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
+github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=
+github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/main.go
+++ b/main.go
@@ -13,9 +13,9 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/gologme/log"
 	"github.com/miekg/dns"
 	"github.com/mikispag/dns-over-tls-forwarder/proxy"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -30,18 +30,6 @@ var (
 func main() {
 	flag.Parse()
 
-	log.SetFormatter(&log.TextFormatter{
-		FullTimestamp:          true,
-		DisableLevelTruncation: true,
-		PadLevelText:           true,
-		TimestampFormat:        "2006-01-02 15:04:05",
-	})
-
-	log.SetLevel(log.InfoLevel)
-	if *isLogVerbose {
-		log.SetLevel(log.DebugLevel)
-	}
-
 	if *logPath != "" {
 		lf, err := os.OpenFile(*logPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0640)
 		if err != nil {
@@ -54,16 +42,10 @@ func main() {
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		log.Infof("%s v%s", path.Base(bi.Path), bi.Main.Version)
 	}
-
-	sigs := make(chan os.Signal, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		<-sigs
-		cancel()
-	}()
+	logger := log.New(os.Stdout, "", log.Flags())
+	mux := dns.NewServeMux()
 	// Run the server with a default cache size and the specified upstream servers.
-	server := proxy.NewServer(0, *evictMetrics, strings.Split(*upstreamServers, ",")...)
+	server := proxy.NewServer(mux, logger, 0, *evictMetrics, *addr, strings.Split(*upstreamServers, ",")...)
 
 	if *ppr != 0 {
 		mux := http.NewServeMux()
@@ -71,7 +53,16 @@ func main() {
 		mux.Handle("/debug/server/", server.DebugHandler())
 		go func() { log.Error(http.ListenAndServe(fmt.Sprintf("localhost:%d", *ppr), mux)) }()
 	}
-	mux := dns.NewServeMux()
 	mux.HandleFunc(".", server.ServeDNS)
-	log.Fatal(server.RunWithMux(ctx, *addr, mux))
+
+	sigs := make(chan os.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-sigs
+		cancel()
+		server.Shutdown(ctx)
+	}()
+
+	log.Fatal(server.Run(ctx))
 }

--- a/main.go
+++ b/main.go
@@ -71,5 +71,5 @@ func main() {
 		go func() { log.Error(http.ListenAndServe(fmt.Sprintf("localhost:%d", *ppr), mux)) }()
 	}
 
-	log.Fatal(server.Run(ctx, *addr))
+	log.Fatal(server.RunWithHandle(ctx, *addr, server.ServeDNS))
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/miekg/dns"
 	"github.com/mikispag/dns-over-tls-forwarder/proxy"
 	log "github.com/sirupsen/logrus"
 )
@@ -70,6 +71,7 @@ func main() {
 		mux.Handle("/debug/server/", server.DebugHandler())
 		go func() { log.Error(http.ListenAndServe(fmt.Sprintf("localhost:%d", *ppr), mux)) }()
 	}
-
-	log.Fatal(server.RunWithHandle(ctx, *addr, server.ServeDNS))
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", server.ServeDNS)
+	log.Fatal(server.RunWithMux(ctx, *addr, mux))
 }

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -137,7 +137,7 @@ func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dn
 func (s *Server) ServeDNS(w dns.ResponseWriter, q *dns.Msg) {
 	inboundIP, _, _ := net.SplitHostPort(w.RemoteAddr().String())
 	log.Debugf("Question from %s: %q", inboundIP, q.Question[0])
-	m := s.getAnswer(q)
+	m := s.GetAnswer(q)
 	if m == nil {
 		dns.HandleFailed(w, q)
 		return
@@ -171,7 +171,7 @@ func (s *Server) DebugHandler() http.Handler {
 	})
 }
 
-func (s *Server) getAnswer(q *dns.Msg) *dns.Msg {
+func (s *Server) GetAnswer(q *dns.Msg) *dns.Msg {
 	m, ok := s.cache.get(q)
 	// Cache HIT.
 	if ok {

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -67,14 +67,12 @@ func NewServer(mux *dns.ServeMux, log *log.Logger, cacheSize int, evictMetrics b
 		Log: log,
 	}
 	if len(upstreamServers) == 0 {
-		s.pools = []*pool{
-			newPool(connectionsPerUpstream, s.connector("one.one.one.one:853@1.1.1.1")),
-			newPool(connectionsPerUpstream, s.connector("dns.google:853@8.8.8.8")),
-		}
-	} else {
-		for _, addr := range upstreamServers {
-			s.pools = append(s.pools, newPool(connectionsPerUpstream, s.connector(addr)))
-		}
+		upstreamServers = []string{"one.one.one.one:853@1.1.1.1", "dns.google:853@8.8.8.8"}
+		s.Log.Infof("No DNS over TLS server addresses provided. Used default servers.")
+	}
+	for _, addr := range upstreamServers {
+		s.Log.Infof("DNS over TLS address: %v", addr)
+		s.pools = append(s.pools, newPool(connectionsPerUpstream, s.connector(addr)))
 	}
 	s.Log.Infof("DNS over TLS forwarder listening on %v", addr)
 	return s

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -99,13 +99,11 @@ func (s *Server) connector(upstreamServer string) func() (*dns.Conn, error) {
 }
 
 // Run runs the server. The server will gracefully shutdown when context is canceled.
-func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dns.ResponseWriter, *dns.Msg)) error {
-	mux := dns.NewServeMux()
-	mux.HandleFunc(".", handler)
+func (s *Server) RunWithMux(ctx context.Context, addr string, mux *dns.ServeMux) error {
 
 	servers := []*dns.Server{
-		{Addr: addr, Net: "tcp", Handler: mux, ReusePort: false},
-		//{Addr: addr, Net: "udp", Handler: mux, ReusePort: false},
+		{Addr: addr, Net: "tcp", Handler: mux},
+		{Addr: addr, Net: "udp", Handler: mux},
 	}
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -76,7 +76,7 @@ func (s *Server) connector(upstreamServer string) func() (*dns.Conn, error) {
 	return func() (*dns.Conn, error) {
 		tlsConf := &tls.Config{
 			// Force TLS 1.2 as minimum version.
-			MinVersion: tls.VersionTLS12,
+			MinVersion: tls.VersionTLS13,
 		}
 		dialableAddress := upstreamServer
 		serverComponents := strings.Split(upstreamServer, "@")
@@ -104,8 +104,8 @@ func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dn
 	mux.HandleFunc(".", handler)
 
 	servers := []*dns.Server{
-		&dns.Server{Addr: addr, Net: "tcp", Handler: mux},
-		&dns.Server{Addr: addr, Net: "udp", Handler: mux},
+		//{Addr: addr, Net: "tcp", Handler: mux},
+		{Addr: addr, Net: "udp", Handler: mux, ReusePort: true},
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -115,9 +115,9 @@ func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dn
 		for _, s := range servers {
 			_ = s.Shutdown()
 		}
-		for _, p := range s.pools {
-			p.shutdown()
-		}
+		//for _, p := range s.pools {
+		//	p.shutdown()
+		//}
 	}()
 
 	go s.refresher(ctx)

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -254,8 +254,9 @@ func (s *Server) forwardMessageAndGetResponse(q *dns.Msg) (m *dns.Msg) {
 		}(p)
 	}
 	for c := 0; c < len(s.pools); c++ {
+		r := <-resps
 		// Return the response only if it has Rcode NoError or NXDomain, otherwise try another pool.
-		if r := <-resps; r != nil && (r.Rcode == dns.RcodeSuccess || r.Rcode == dns.RcodeNameError) {
+		if r != nil && (r.Rcode == dns.RcodeSuccess || r.Rcode == dns.RcodeNameError) {
 			return r
 		}
 	}

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -99,9 +99,9 @@ func (s *Server) connector(upstreamServer string) func() (*dns.Conn, error) {
 }
 
 // Run runs the server. The server will gracefully shutdown when context is canceled.
-func (s *Server) Run(ctx context.Context, addr string) error {
+func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dns.ResponseWriter, *dns.Msg)) error {
 	mux := dns.NewServeMux()
-	mux.Handle(".", s)
+	mux.HandleFunc(".", handler)
 
 	servers := []*dns.Server{
 		&dns.Server{Addr: addr, Net: "tcp", Handler: mux},

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -104,8 +104,8 @@ func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dn
 	mux.HandleFunc(".", handler)
 
 	servers := []*dns.Server{
-		//{Addr: addr, Net: "tcp", Handler: mux},
-		{Addr: addr, Net: "udp", Handler: mux, ReusePort: true},
+		{Addr: addr, Net: "tcp", Handler: mux, ReusePort: false},
+		//{Addr: addr, Net: "udp", Handler: mux, ReusePort: false},
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -115,9 +115,9 @@ func (s *Server) RunWithHandle(ctx context.Context, addr string, handler func(dn
 		for _, s := range servers {
 			_ = s.Shutdown()
 		}
-		//for _, p := range s.pools {
-		//	p.shutdown()
-		//}
+		for _, p := range s.pools {
+			p.shutdown()
+		}
 	}()
 
 	go s.refresher(ctx)

--- a/proxy/server_test.go
+++ b/proxy/server_test.go
@@ -138,7 +138,7 @@ func setupTestServer(tb testing.TB, cacheSize int, responder func(q string) stri
 		ts.s = NewServer(cacheSize, false, raddr)
 		ts.s.dial = flst.dialer()
 		go func() {
-			if err := ts.s.Run(ctx, ts.laddr); err != nil {
+			if err := ts.s.RunWithHandle(ctx, ts.laddr, ts.s.ServeDNS); err != nil {
 				tb.Errorf("Cannot run Server: %v", err)
 			}
 		}()


### PR DESCRIPTION
Complex improvements for DNS over TLS forwarder. These changes are moving this project to a library not just an app.

Changes:
1. Port reuse seted up true
2. Split Run and Shutdown code
3. Added ability to receive an external logger
4. TODO: in Windows cache test is failing with error:
"Only one usage of each socket address (protocol/network address/port) is normally permitted."
Not quite sure where to fix the error.